### PR TITLE
fix: Fix bin reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@crunchloop/mcp-teamtailor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@crunchloop/mcp-teamtailor",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.7.0",
         "zod": "^3.24.2"
       },
       "bin": {
-        "teamtailor-mcp": "dist/index.js"
+        "teamtailor-mcp": "bin/teamtailor-mcp"
       },
       "devDependencies": {
         "@eslint/js": "^9.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crunchloop/mcp-teamtailor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MCP for Teamtailor",
   "private": false,
   "license": "MIT",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "bin": {
-    "teamtailor-mcp": "dist/index.js"
+    "teamtailor-mcp": "bin/teamtailor-mcp"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ const client = new TeamtailorClient(
 
 const server = new McpServer({
   name: "teamtailor",
-  version: "0.0.1"
+  version: "0.0.2"
 });
 
 server.tool(


### PR DESCRIPTION
This pull request updates the version of the `@crunchloop/mcp-teamtailor` package and adjusts the binary path to reflect a new file structure. It also updates the version used in the server configuration to maintain consistency.

Version updates:

* Updated the version in `package.json` from `0.0.1` to `0.0.2` to reflect a new release.
* Updated the version in the `McpServer` configuration in `src/server.ts` to match the new package version (`0.0.2`).

File structure changes:

* Changed the binary path in `package.json` from `dist/index.js` to `bin/teamtailor-mcp` to align with the updated project structure.